### PR TITLE
Check gpuIx when no GPU

### DIFF
--- a/runModel.py
+++ b/runModel.py
@@ -175,7 +175,8 @@ def getModelResults(
         options = "--ipc=host"
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
-        if gpuIx is not None and gpuIx >= 0:
+#        if gpuIx is not None and gpuIx >= 0:
+        if gpuIx and gpuIx >= 0:
             options += " --gpus device=" + str(gpuIx)
 
         dockerCommand += " " + options


### PR DESCRIPTION
* when on a machine with no GPU
* ... and USE_GPU=None in backend/.env
Then apparently, the value of gpuIx passed here is an empty string, which is not the same as None.
So the test causes the inference task to fail with the error: `model_inference_site[1238]: Command stderr: docker: Error response from daemon: could not select device driver "" with capabilities: [[gpu]].`
Changing the test to `if gpuIx and gpuIx >= 0:` removes the error.
Haven't tried it on a machine with GPU.