### PR TITLE
USE_GPU can now be a number, 'all', or "None"

### DIFF
--- a/runModel.py
+++ b/runModel.py
@@ -630,12 +630,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-g",
         "--gpuIx",
-        type=int,
+        type=str,  # Accepts both integers as strings and 'all'
         metavar="",
         default=None,
-        help="GPU index. Defaults to None",
+        help="GPU index. Can be an integer or 'all'. Defaults to None",
     )
-
     parser.add_argument(
         "-t",
         "--minConfidenceThreshold",

--- a/runModel.py
+++ b/runModel.py
@@ -175,11 +175,6 @@ def getModelResults(
         options = "--ipc=host"
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
-#        if gpuIx is not None and gpuIx >= 0:
-#        if isinstance(gpuIx, int) and gpuIx >= 0:
-#            options += f" --gpus device={gpuIx}"
-#        elif gpuIx == "all":
-#            options += " --gpus all"
 
         if not gpuIx:  # empty string or None
             # Don't add GPU option

--- a/runModel.py
+++ b/runModel.py
@@ -175,7 +175,8 @@ def getModelResults(
         options = "--ipc=host"
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
-        if gpuIx is not None and gpuIx >= 0:
+#        if gpuIx is not None and gpuIx >= 0:
+        if gpuIx and gpuIx >= 0:
             options += " --gpus device=" + str(gpuIx)
 
         dockerCommand += " " + options

--- a/runModel.py
+++ b/runModel.py
@@ -176,8 +176,10 @@ def getModelResults(
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
 #        if gpuIx is not None and gpuIx >= 0:
-        if gpuIx and gpuIx >= 0:
-            options += " --gpus device=" + str(gpuIx)
+        if isinstance(gpuIx, int) and gpuIx >= 0:
+            options += f" --gpus device={gpuIx}"
+        elif gpuIx == "all":
+            options += " --gpus all"
 
         dockerCommand += " " + options
 

--- a/runModel.py
+++ b/runModel.py
@@ -176,10 +176,23 @@ def getModelResults(
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
 #        if gpuIx is not None and gpuIx >= 0:
-        if isinstance(gpuIx, int) and gpuIx >= 0:
-            options += f" --gpus device={gpuIx}"
-        elif gpuIx == "all":
+#        if isinstance(gpuIx, int) and gpuIx >= 0:
+#            options += f" --gpus device={gpuIx}"
+#        elif gpuIx == "all":
+#            options += " --gpus all"
+
+        if not gpuIx:  # empty string or None
+            # Don't add GPU option
+            pass
+        elif gpuIx.lower() == "all":
             options += " --gpus all"
+        else:
+            try:
+                gpuIx_int = int(gpuIx)
+                if gpuIx_int >= 0:
+                    options += f" --gpus device={gpuIx_int}"
+            except ValueError:
+                raise RuntimeError(f"Invalid USE_GPU value: {gpuIx!r}")
 
         dockerCommand += " " + options
 

--- a/runModel.py
+++ b/runModel.py
@@ -176,18 +176,16 @@ def getModelResults(
         if sharedMemorySizeStr:
             options += " --shm-size=" + sharedMemorySizeStr
 
-        if not gpuIx:  # empty string or None
-            # Don't add GPU option
-            pass
-        elif gpuIx.lower() == "all":
+        # Add GPU option
+        gpuIx = gpuIx.strip()
+        if gpuIx.lower() == "all":
             options += " --gpus all"
-        else:
-            try:
-                gpuIx_int = int(gpuIx)
-                if gpuIx_int >= 0:
-                    options += f" --gpus device={gpuIx_int}"
-            except ValueError:
-                raise RuntimeError(f"Invalid USE_GPU value: {gpuIx!r}")
+        elif gpuIx.isdigit():
+            gpuIx_int = int(gpuIx)
+            if gpuIx_int >= 0:
+                options += f" --gpus device={gpuIx_int}"
+        elif gpuIx:  # non-empty but not valid
+            raise RuntimeError(f"Invalid USE_GPU value: {gpuIx!r}")
 
         dockerCommand += " " + options
 

--- a/runModel.py
+++ b/runModel.py
@@ -177,15 +177,18 @@ def getModelResults(
             options += " --shm-size=" + sharedMemorySizeStr
 
         # Add GPU option
-        gpuIx = gpuIx.strip()
-        if gpuIx.lower() == "all":
+        if gpuIx is None or gpuIx.strip() == "":
+            # Do nothing: no GPU flag
+            pass
+        elif gpuIx.lower() == "all":
             options += " --gpus all"
-        elif gpuIx.isdigit():
-            gpuIx_int = int(gpuIx)
-            if gpuIx_int >= 0:
-                options += f" --gpus device={gpuIx_int}"
-        elif gpuIx:  # non-empty but not valid
-            raise RuntimeError(f"Invalid USE_GPU value: {gpuIx!r}")
+        else:
+            try:
+                gpuIx_int = int(gpuIx)
+                if gpuIx_int >= 0:
+                    options += f" --gpus device={gpuIx_int}"
+            except ValueError:
+                raise RuntimeError(f"Invalid USE_GPU value: {gpuIx!r}")
 
         dockerCommand += " " + options
 


### PR DESCRIPTION
gpuIx set in .env can now be a number, 'all', or "None"

e.g. (in .env)
USE_GPU=None  # will run on CPU
or
USE_GPU=0  # will use GPU 0
or
USE_GPU=all  # will use GPU 0 and 1

not correct:
USE_GPU=   # no value: will give an error at inference start

Note that using multiple GPUs during inference is not faster, as GPUs have to communicate wicth each other and that results  in significant overhead.

Sufficiently tested and has been running smoothly for 14 days now